### PR TITLE
improved docstring, renamed  references to connectVSD in connect

### DIFF
--- a/examples/check-file-exists-in-object.py
+++ b/examples/check-file-exists-in-object.py
@@ -14,13 +14,13 @@ CHANGES
 
 """
 
-from vsdConnect import connectVSD
+from vsdConnect import connect
 import os
 from pathlib import Path, PurePath, WindowsPath
 
 
 ## connect using credentials
-api=connectVSD.VSDConnecter(url='https://demo.virtualskeleton.ch/api/', username= "demo@virtualskeleton.ch", password = "demo")
+api=connect.VSDConnecter(url='https://demo.virtualskeleton.ch/api/', username= "demo@virtualskeleton.ch", password = "demo")
 
 ## specify the local file
 fp = Path('D:' + os.sep, 'hash','vsd_file_926373_20160226_120352.stl')

--- a/examples/downloadImages.py
+++ b/examples/downloadImages.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-from vsdConnect import connectVSD
+from vsdConnect import connect
 import sys
 import argparse
 
@@ -22,8 +22,8 @@ if (args.targetProject=="" and args.sourceFolderID=="" and args.sourceFolderName
     print "Arguments incomplete, need either ID or name of VSD folder"
     sys.exit()
 
-#con=connectVSD.VSDConnecter("username","password")
-#con=connectVSD.VSDConnecter()
+con=connect.VSDConnecter("username","password")
+#con=connect.VSDConnecter()
 
 
 

--- a/examples/getVSDFolderIDs.py
+++ b/examples/getVSDFolderIDs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-from vsdConnect import connectVSD
+from vsdConnect import connect
 import sys
 import argparse
 
@@ -8,9 +8,9 @@ parser = argparse.ArgumentParser(description='Download original image files from
 
 
 args=parser.parse_args()
-#con=connectVSD.VSDConnecter("username","password")
-#con=connectVSD.VSDConnecter()
-con=connectVSD.VSDConnecter("ZGVtb0B2aXJ0dWFsc2tlbGV0b24uY2g6ZGVtbw==")
+#con=connect.VSDConnecter("username","password")
+#con=connect.VSDConnecter()
+con=connect.VSDConnecter("ZGVtb0B2aXJ0dWFsc2tlbGV0b24uY2g6ZGVtbw==")
 con.seturl("https://demo.virtualskeleton.ch/api/")
 
 print "Retrieving folder list from SMIR.."

--- a/vsdConnect/connect.py
+++ b/vsdConnect/connect.py
@@ -54,7 +54,7 @@ try:
 except:
     import xml.etree.ElementTree as ET
 
-import models as vsdModels
+import vsdConnect.models as vsdModels
 import logging
 
 logger = logging.getLogger(__name__)

--- a/vsdConnect/models.py
+++ b/vsdConnect/models.py
@@ -60,10 +60,10 @@ class ListValidator(object):
 class URLField(fields.StringField):
     pass #add url-specific fields?
 
-class longIntField(fields.IntField):
-    types = (int, long,)
-
-fields.longIntField = longIntField
+#see http://python3porting.com/differences.html#long
+import sys
+if sys.version_info < (3,):
+    fields.IntField.types = (int, long,)
 
 ##########################################
 # Attributes Data
@@ -288,7 +288,7 @@ class File(APIBaseID):
     downloadUrl = URLField()
     originalFileName = fields.StringField()
     anonymizedFileHashCode = fields.StringField()
-    size = fields.longIntField()
+    size = fields.IntField()  #in Python 2 it needs the patch for long type
     fileHashCode = fields.StringField()
     objects = fields.EmbeddedField(Pagination) #ObjectPagination
 


### PR DESCRIPTION
I added only some documentation to the new methods.
The "return" field of the doc string is not very precise, because some methods are a sort of factory (for example, APIObject._create is actually a constructor for different types of objects)

So, I didn't touch the methods that I am not using and still rely on accessing directly the json dict instead of using jsonmodels (for example getLicenseList, getObjectRightList....) 

From the point of view of documenting the new method, I can add that now there are some (possible) redundancies:
- I saw some logic of the apisession has been moved in models.py , but I haven't checked if something is now redundant (I only noticed APIObject._create and APIObject._get_object_type and made them classmethods)
- isn't downloadZip the same as downloadObject?
- getPaginated is not used (at least in my projects)
- getAllPaginated can be replaced by list(iterateAllPaginated)
- getObjects and getAllUnpublishedObjects are almost equivalent
- getResource and _instantiateResource seem not be used, but I am using them to actually populate an object (and its embeddeded fields) automatically, would be interesting to move them in  models.py? 
- there is some overlap between walkFolder and getContainedFolders, getContainedObjects, getFolderContent 
